### PR TITLE
fix: bump @solana/kit to ^6.1.0 to satisfy @x402/svm peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payai/x402-fetch-starter",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": false,
   "description": "Create an x402 Fetch client in less than 2 minutes!",
   "type": "module",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@scure/base": "^1.2.6",
-    "@solana/kit": "^2.1.1",
+    "@solana/kit": "^6.1.0",
     "@x402/evm": "^2.3.0",
     "@x402/fetch": "^2.3.0",
     "@x402/svm": "^2.3.0",


### PR DESCRIPTION
## Summary

- Bump `@solana/kit` from `^2.1.1` to `^6.1.0` in `template/package.json`
- Bump starter version `2.3.0` → `2.3.1`

## Why

`@x402/svm@2.x` declares a peer dependency on `@solana/kit >=5.1.0`. With `@solana/kit` pinned at `^2.1.1`, running the freshly-scaffolded starter produces an `ERESOLVE` failure:

```
npm error While resolving: my-first-client@undefined
npm error Found: @solana/kit@2.3.0
npm error Could not resolve dependency:
npm error peer @solana/kit@">=5.1.0" from @x402/svm@2.12.0
```

`^6.1.0` matches what the upstream `coinbase/x402` example currently uses.

## Scope

Intentionally minimal — only the `@solana/kit` line moves. `@x402/*` dependencies and the rest of the template are unchanged so this can land independently of the larger sync in #20.

## Test plan

- [x] `npx @payai/x402-fetch-starter@latest my-first-client` (with this fix applied locally) installs cleanly
- [x] `npm run dev` against a local x402 server (`my-first-server` on :4021) returns a settled payment response