### PR TITLE
docs: mark starter as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!WARNING]
+> ## Deprecated — no longer maintained
+>
+> This starter is retired. Install the x402 packages directly instead and follow the
+> **[PayAI x402 quickstart](https://docs.payai.network/x402/quickstart)**, which carries the
+> same working example inline.
+>
+> The npm package stays installable so existing builds keep working, but it will not
+> receive updates. This repository is archived and read-only.
+
 # x402 Fetch Starter
 
 Starter for running an x402 fetch client.


### PR DESCRIPTION
Adds a deprecation notice to the top of the README, ahead of archiving this repo.

The five `@payai/x402-*-starter` packages are deprecated on npm as of 2026-08-04 — all versions, `npm deprecate` rather than unpublish, so existing consumers keep building.

**Why the README matters separately from the npm deprecation:** npm serves the README captured at publish time, so this edit will not change the npm package page (that already shows npm's own deprecation banner). This is for people who land on the GitHub repo — and notably, `npx` does *not* surface the npm deprecation warning for the package it executes, so a stale `npx` instruction currently redirects nobody.

Both workflows on this repo are disabled, so merging will not trigger a publish.

Readers are pointed at the [PayAI x402 quickstart](https://docs.payai.network/x402/quickstart), which carries the same working example inline.